### PR TITLE
Dynamic descriptions, header fix, and new event

### DIFF
--- a/ModMenu/Helpers.cs
+++ b/ModMenu/Helpers.cs
@@ -67,6 +67,14 @@ namespace ModMenu
       }
     }
 
+    /// <summary>
+    /// Updated the Description field of a setting that is set with WithLongDescription(). The update works by finding the Title of the setting.
+    /// Titles that you wish to update must be unique inorder to update the correct setting.
+    /// </summary>
+    /// <typeparam name="T">
+    /// This needs to be a class of the type that inherits from SettingsEntityWithValueVM that you wish to update. Such as if you are updating a slider the typeparam
+    /// must be SettingsEntitySliderVM
+    /// </typeparam>
 
     internal class SettingsDescriptionUpdater<T>
         where T : SettingsEntityWithValueVM
@@ -81,9 +89,24 @@ namespace ModMenu
       private List<SettingsEntityWithValueView<T>> settingViews;
       private SettingsDescriptionPCView descriptionView;
 
-      public SettingsDescriptionUpdater(string pathUI, string pathDesriptionUI)
+      /// <summary>
+      /// Constuctor for SettingsDescriptionUpdater. Sets up the paths for where the UI gameobjects at located
+      /// </summary>
+      /// <param name="pathMainUI">
+      /// This is the path to main UI where setting GameOjects are located are located.
+      /// </param>
+      /// <remarks>
+      /// As of 2.1.5r pathMainUI would be "Canvas/SettingsView/ContentWrapper/VirtualListVertical/Viewport/Content"
+      /// </remarks>
+      /// <param name="pathDesriptionUI">
+      /// This is the path to the Description UI where the Description GameOject SettingsDescriptionPCView is located.
+      /// <remarks>
+      /// As of 2.1.5r pathDesriptionUI would be "Canvas/SettingsView/ContentWrapper/DescriptionView"
+      /// </remarks>
+      /// </param>
+      public SettingsDescriptionUpdater(string pathMainUI, string pathDesriptionUI)
       {
-        pathMainUi = pathUI;
+        pathMainUi = pathMainUI;
         pathDescriptionUi = pathDesriptionUI;
       }
 
@@ -108,10 +131,22 @@ namespace ModMenu
         return true;
       }
 
-      public bool TryUpdate(string title, string desription)
+      /// <summary>
+      /// This is the method that updates the Description of the SettingsEntityWithValueVM
+      /// </summary>
+      /// <param name="title">
+      /// This is the UNIQUE Title of the setting that you wish to edit. If the Title is
+      /// not unique then the incorrect setting may be updated.
+      /// </param>
+      /// <param name="description">
+      /// The text you wish to set the Description to.
+      /// </param>
+      /// <returns>
+      /// Will return true if the update was successfull.
+      /// </returns>
+      
+      public bool TryUpdate(string title, string description)
       {
-        // Searches for the title of the setting you are attempt to change. The only downside is that titles must be unique for the description you are attempting to change.
-
         if (!Ensure()) return false;
 
         T svm = null;
@@ -122,16 +157,16 @@ namespace ModMenu
           if (test.Title.Equals(title))
           {
             svm = test;
-            break;
+              break;
           }
         }
 
         if (svm == null)
           return false;
 
-        svm.GetType().GetField("Description").SetValue(svm, desription);
+        svm.GetType().GetField("Description").SetValue(svm, description);
 
-        descriptionView.m_DescriptionText.text = desription;
+        descriptionView.m_DescriptionText.text = description;
 
         return true;
       }

--- a/ModMenu/NewTypes/ISettingsChanged.cs
+++ b/ModMenu/NewTypes/ISettingsChanged.cs
@@ -2,9 +2,18 @@
 
 namespace ModMenu.NewTypes
 {
-  // Event interface that can be subscribed to in PubSubSytem that handles when Apply Settings happens in the Settings UI
+  /// <summary>
+  /// Event interface that can be subscribed to on the EventBus that handles when Apply button is pressed in the Settings UI.
+  /// </summary>
+  /// <remarks>
+  /// Your class must subscribe to the EventBus for this to trigger via EventBus.Subscribe(object subscriber)
+  /// </remarks>
+ 
   public interface ISettingsChanged : ISubscriber, IGlobalSubscriber
   {
+    /// <summary>
+    /// Method triggered when with SettingsVM.ApplySettings() is called.
+    /// </summary>
     void HandleApplySettings();
   }
 }

--- a/ModMenu/NewTypes/ISettingsChanged.cs
+++ b/ModMenu/NewTypes/ISettingsChanged.cs
@@ -1,0 +1,10 @@
+﻿using Kingmaker.PubSubSystem;
+
+namespace ModMenu.NewTypes
+{
+  // Event interface that can be subscribed to in PubSubSytem that handles when Apply Settings happens in the Settings UI
+  public interface ISettingsChanged : ISubscriber, IGlobalSubscriber
+  {
+    void HandleApplySettings();
+  }
+}

--- a/ModMenu/NewTypes/SettingsEntityPatches.cs
+++ b/ModMenu/NewTypes/SettingsEntityPatches.cs
@@ -337,7 +337,7 @@ namespace ModMenu.NewTypes
         [HarmonyPatch(nameof(SettingsVM.ApplySettings)), HarmonyPostfix]
         static void Postfix()
         {
-          // Raise Event when Apply Settings button is press in the settings UI
+          // Raise Event when Apply button is press in the settings UI
           EventBus.RaiseEvent<ISettingsChanged>(h => h.HandleApplySettings());
         }
       }

--- a/ModMenu/NewTypes/SettingsEntityPatches.cs
+++ b/ModMenu/NewTypes/SettingsEntityPatches.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using Kingmaker.PubSubSystem;
 using Kingmaker.UI.MVVM._PCView.ServiceWindows.Journal;
 using Kingmaker.UI.MVVM._PCView.Settings;
 using Kingmaker.UI.MVVM._PCView.Settings.Entities;
@@ -328,6 +329,17 @@ namespace ModMenu.NewTypes
         templatePrefab.ButtonLabel = buttonLabel;
 
         return templatePrefab;
+      }
+
+      [HarmonyPatch(typeof(SettingsVM))]
+      static class ApplySettings_Patch
+      {
+        [HarmonyPatch(nameof(SettingsVM.ApplySettings)), HarmonyPostfix]
+        static void Postfix()
+        {
+          // Raise Event when Apply Settings button is press in the settings UI
+          EventBus.RaiseEvent<ISettingsChanged>(h => h.HandleApplySettings());
+        }
       }
     }
   }

--- a/ModMenu/Settings/HeaderFix.cs
+++ b/ModMenu/Settings/HeaderFix.cs
@@ -1,0 +1,31 @@
+﻿using Kingmaker.PubSubSystem;
+using Kingmaker;
+using UnityEngine;
+using Kingmaker.Utility;
+using HarmonyLib;
+using Kingmaker.Blueprints.JsonSystem;
+
+namespace ModMenu.Settings
+{
+  internal class HeaderFix
+  {
+    [HarmonyPatch(typeof(BlueprintsCache))]
+    static class BlueprintsCache_Patch
+    {
+      [HarmonyPatch(nameof(BlueprintsCache.Init)), HarmonyPostfix]
+      static void Postfix()
+      {
+        EventBus.Subscribe(new Fix());
+      }
+    }
+  }
+
+  internal class Fix : ISettingsUIHandler
+  {
+    public void HandleOpenSettings(bool isMainMenu = false)
+    {
+      foreach (RectTransform transform in Game.Instance.RootUiContext.m_CommonView?.transform.Find("Canvas/SettingsView/ContentWrapper/MenuSelectorPCView"))
+        transform.ResetScale();
+    }
+  }
+}

--- a/ModMenu/Settings/TestSettings.cs
+++ b/ModMenu/Settings/TestSettings.cs
@@ -1,8 +1,12 @@
 ﻿using Kingmaker.Localization;
+using Kingmaker.PubSubSystem;
+using Kingmaker.UI.MVVM._VM.Settings.Entities;
 using Kingmaker.UI.SettingsUI;
+using ModMenu.NewTypes;
 using System.Text;
 using UnityEngine;
 using static Kingmaker.UI.KeyboardAccess;
+using static ModMenu.Helpers;
 
 namespace ModMenu.Settings
 {
@@ -10,7 +14,7 @@ namespace ModMenu.Settings
   /// <summary>
   /// Test settings group shown on debug builds to validate usage.
   /// </summary>
-  internal class TestSettings
+  internal class TestSettings : ISettingsChanged
   {
     private static readonly string RootKey = "mod-menu.test-settings";
     private enum TestEnum
@@ -36,6 +40,10 @@ namespace ModMenu.Settings
             Toggle.New(GetKey("toggle"), defaultValue: true, CreateString("toggle-desc", "This is a toggle"))
               .ShowVisualConnection()
               .OnValueChanged(OnToggle))
+          .AddToggle(
+            Toggle.New(GetKey("toggle-updateable"), defaultValue: true, CreateString("toggle-updateable-desc", "This is a toggle changes the LongDescription text!"))
+              .ShowVisualConnection()
+              .OnTempValueChanged(OnToggleUDescriptionUpdate))
           .AddDropdown(
             Dropdown<TestEnum>.New(
                 GetKey("dropdown"),
@@ -48,7 +56,7 @@ namespace ModMenu.Settings
                 CreateString(
                   "dropdown-long-desc",
                   "This is a dropdown based on TestEnum. In order to change the value the connected toggle must be on."
-                  +" After switching it on or off exit and enter the menu again to lock/unlock it."))
+                  + " After switching it on or off exit and enter the menu again to lock/unlock it."))
               .DependsOnSave())
           .AddSubHeader(CreateString("sub-header", "Test Sliders"))
           .AddSliderFloat(
@@ -132,6 +140,8 @@ namespace ModMenu.Settings
                   CreateString("dropdown-button-3", "Button calls onClick(2)"),
                 })
               .OnTempValueChanged(value => Main.Logger.Log($"Currently selected dropdown button is {value}"))));
+
+      EventBus.Subscribe(this);
     }
 
     private void OnKeyPress()
@@ -163,6 +173,15 @@ namespace ModMenu.Settings
       return ModMenu.GetSettingValue<bool>(GetKey("toggle"));
     }
 
+    public void OnToggleUDescriptionUpdate(bool value)
+    {
+      var pathMainUi = "Canvas/SettingsView/ContentWrapper/VirtualListVertical/Viewport/Content";
+      var pathDescriptionUi = "Canvas/SettingsView/ContentWrapper/DescriptionView";
+      
+      SettingsDescriptionUpdater<SettingsEntityBoolVM> sdu = new(pathMainUi, pathDescriptionUi);
+      sdu.TryUpdate("This is a toggle changes the LongDescription text!", $"Hey this value is now {value}");
+    }
+
     private void OnToggle(bool value)
     {
       Main.Logger.Log($"Toggle switched to {value}");
@@ -181,6 +200,11 @@ namespace ModMenu.Settings
     private static string GetKey(string partialKey)
     {
       return $"{RootKey}.{partialKey}";
+    }
+
+    public void HandleApplySettings()
+    {
+      Main.Logger.Log("'Apply' button in the settings window was pressed!");
     }
   }
 #endif


### PR DESCRIPTION
* Helper SettingsDescriptionUpdater will update a settings long description dynamically. 
* An event is trigger when the Settings UI is opened to ensure the scale is 1. This fixes the header button being too big in the in game settings menu. 
* New PubSubSystem interface that triggers when the Settings UI calls ApplySettings